### PR TITLE
use instance vars to format message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -336,6 +336,7 @@ impl SlackNotifier {
                     .as_ref()
                     .map(String::as_ref)
                     .unwrap_or(""),
+                metadata.pipeline_instance_vars,
                 metadata.job_name.as_ref().map(String::as_ref).unwrap_or(""),
                 metadata
                     .name


### PR DESCRIPTION
This is a rebased version of https://github.com/mockersf/concourse-slack-notifier/pull/86

This add support of instance vars to the message format.

Since it's unclear to me whether https://github.com/mockersf/concourse-slack-notifier and https://github.com/aoldershaw/concourse-slack-notifier are still maintained, I host an up-to-date fork here.

(cherry picked from commit 2affc26ede9f89d4676824502c20b86ef58aa05d) [mkorpershoek: fixed concourse-resource dep since has 3.0 has instance support]